### PR TITLE
feat(ci): Add PyPI publish workflow for OneBot Adapter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish OneBot Adapter to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/onebot_adapter
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build wheel
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build package
+        run: |
+          python -m build
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: onebot-adapter-dists
+          path: plugins/onebot_adapter/dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/chatgpt-mirai-qq-bot-onebot-adapter
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: onebot-adapter-dists
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/ 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 from setuptools import setup, find_packages
 import io
+import os
+
+version = os.environ.get('RELEASE_VERSION', '0.1.0').lstrip('v')
+
 setup(
     name="chatgpt-mirai-qq-bot-onebot-adapter",
-    version="0.1.0",
+    version=version,
     packages=find_packages(),
     install_requires=[
-        "aiocqhttp",
+        "aiocqhttp[all]>=1.4.4",
     ],
     author="Cloxl",
     author_email="cloxl2017@outlook.at",


### PR DESCRIPTION
- Create GitHub Actions workflow to automatically publish package on release
- Configure version extraction from release tag
- Set up build and distribution steps for PyPI release
- Update setup.py to dynamically use release version from environment