### PR TITLE
chore: declare upper-bond version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Build and Publish OneBot Adapter
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ closed ]
   push:
     tags:
       - 'v*'
@@ -13,91 +10,8 @@ permissions:
   id-token: write
 
 jobs:
-  # 只在 PR 被合并到 main 分支时运行
-  build-and-publish:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # 获取所有历史记录和 tags
-      
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-      
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build wheel
-      
-      # 自动生成版本号
-      - name: Generate version
-        id: generate_version
-        run: |
-          # 获取最新的版本号
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          LATEST_VERSION=${LATEST_TAG#v}
-          
-          # 拆分版本号
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
-          
-          # 增加补丁版本号
-          PATCH=$((PATCH + 1))
-          
-          # 新版本号
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          NEW_TAG="v$NEW_VERSION"
-          
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
-          echo "Generated new version: $NEW_VERSION (tag: $NEW_TAG)"
-      
-      # 创建新的 tag
-      - name: Create Tag
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git tag -a ${{ env.NEW_TAG }} -m "Release ${{ env.NEW_TAG }}"
-          git push origin ${{ env.NEW_TAG }}
-      
-      # 构建包
-      - name: Build package
-        run: |
-          python -m build
-        env:
-          RELEASE_VERSION: ${{ env.NEW_VERSION }}
-      
-      # 上传构建产物
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: onebot-adapter-${{ env.NEW_VERSION }}
-          path: dist/
-      
-      # 创建 Release
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.NEW_TAG }}
-          name: Release ${{ env.NEW_TAG }}
-          files: dist/*
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-      
-      # 发布到 PyPI
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-          skip-existing: true
-  
-  # 处理手动创建的 tag
   release-from-tag:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     
     steps:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
 from setuptools import setup, find_packages
 import io
 import os
-
-version = os.environ.get('RELEASE_VERSION', '0.1.0').lstrip('v')
-
+                                                                                                                                                                                                                                                                                                                                        
 setup(
     name="chatgpt-mirai-qq-bot-onebot-adapter",
-    version=version,
+    version="0.2.4.post1",
     packages=find_packages(),
     install_requires=[
         "aiocqhttp[all]>=1.4.4",
+        "kirara-ai<3.2.0"
     ],
     entry_points={
         'chatgpt_mirai.plugins': [
@@ -19,7 +18,7 @@ setup(
     author="Cloxl",
     author_email="cloxl2017@outlook.at",
 
-    description="OneBot adapter for lss233/chatgpt-mirai-qq-bot",
+    description="OneBot adapter for Kirara AI",
     long_description=io.open("README.md", encoding='utf-8').read(),
     long_description_content_type="text/markdown",
     url="https://github.com/cloxl/chatgpt-mirai-qq-bot-onebot-adapter",


### PR DESCRIPTION
1. 去掉了自动生成版本号并且发布的逻辑，感觉这很容易造成灾难。
2. 在 `0.2.4` 版本上宣布最高支持的版本，以便后续基于新版本的 API 继续开发。

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

移除自动版本生成并为项目设置版本约束上限

增强功能：
- 为 'kirara-ai' 依赖添加版本约束上限

CI：
- 简化 GitHub Actions 工作流程，仅在推送标签时触发

杂项：
- 移除自动版本递增和基于 PR 发布版本的 GitHub Actions 工作流程
- 显式设置项目版本为 0.2.4.post1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove automatic version generation and set an upper-bound version constraint for the project

Enhancements:
- Add an upper-bound version constraint for the 'kirara-ai' dependency

CI:
- Simplify GitHub Actions workflow to only trigger on tag pushes

Chores:
- Remove automatic version bumping and GitHub Actions workflow for PR-based releases
- Explicitly set project version to 0.2.4.post1

</details>